### PR TITLE
Add map option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var _parser = require('./src/parser');
 var _converter = require('./src/converter');
+var _config = require('./src/config');
 
 
 /**
@@ -27,3 +28,8 @@ exports.convert = _converter.convert;
  */
 exports.batchConvert = _converter.batchConvert;
 
+/**
+ * Configure nodefy
+ * @param Object options
+ */
+exports.config = _config.configure;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,33 @@
+
+var config = {};
+
+var defaults = {
+    'map': {}
+};
+
+function configure(options) {
+  for (var key in options) {
+    if (defaults[key] == null) {
+        throw new Error('Unknown configuration option: ' + key);
+    }
+    if (typeof defaults[key] !== typeof options[key]) {
+        throw new Error('Invalid type for option: ' + key);
+    }
+    if (key === 'map') {
+        for (var mapKey in options[key]) {
+            if (mapKey !== '*') {
+                throw new Error('Only global (*) module remappings are supported');
+            }
+        }
+    }
+    config[key] = options[key];
+  }
+}
+
+
+config.configure = configure;
+config.defaults = defaults;
+
+configure(defaults);
+
+module.exports = config;

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,5 +1,6 @@
 
 var esprima = require('esprima');
+var _config = require('./config');
 
 
 var MAGIC_DEPS = {
@@ -57,6 +58,7 @@ function getRequires(args, factory){
             dep : (deps.length)? deps[i] : SIMPLIFIED_CJS[i]
         };
     });
+    var mapLookup = _config.map['*'] || {};
 
     params.forEach(function(param){
         if ( MAGIC_DEPS[param.dep] && !MAGIC_DEPS[param.name] ) {
@@ -65,7 +67,8 @@ function getRequires(args, factory){
         } else if ( param.dep && !MAGIC_DEPS[param.dep] ) {
             // only do require for params that have a matching dependency also
             // skip "magic" dependencies
-            requires.push( 'var '+ param.name +' = require(\''+ param.dep +'\');' );
+            var depName = mapLookup[param.dep] || param.dep;
+            requires.push( 'var '+ param.name +' = require(\''+ depName +'\');' );
         }
     });
 

--- a/test/files/map-in.js
+++ b/test/files/map-in.js
@@ -1,0 +1,13 @@
+// test comment
+define(['foo', '../bar/baz'], function (foo, baz) {
+
+    // another comment
+    var ipsum = 'dolor amet';
+
+    return {
+        doFoo: function(){
+            foo.bar( baz.dolor, ipsum );
+        }
+    };
+});
+

--- a/test/files/map-out.js
+++ b/test/files/map-out.js
@@ -1,0 +1,14 @@
+// test comment
+var foo = require('baz');
+var baz = require('../bar/baz');
+
+    // another comment
+    var ipsum = 'dolor amet';
+
+    module.exports = {
+        doFoo: function(){
+            foo.bar( baz.dolor, ipsum );
+        }
+    };
+
+

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -53,5 +53,14 @@ describe('parse', function () {
         expect( output ).toEqual( readOut('nested/deep/plugin') );
     });
 
+    it('should do map replacement of dependencies', function () {
+        nodefy.config({
+            map: {'*': {'foo': 'baz'}}
+        })
+        var output = nodefy.parse( readIn('map') );
+        expect( output ).toMatch( /require\(['"]\w/ );
+        expect( output ).toEqual( readOut('map') );
+    });
+
 });
 


### PR DESCRIPTION
Added simplified map option (ref #6)

Only accepts `'*'` global maps, i.e:

``` javascript
nodefy.configure({
  map: {
    '*': {'foo': 'bar'}
  }
})
```
